### PR TITLE
Fixed UiWidget by making it upright by default

### DIFF
--- a/src/Sodalite/src/UiWidgets/Widgets/UiWidget.cs
+++ b/src/Sodalite/src/UiWidgets/Widgets/UiWidget.cs
@@ -31,6 +31,9 @@ namespace Sodalite.UiWidgets
 
 			// If we have an audio source somewhere in the parent we want that too
 			AudioSource = GetComponentInParent<AudioSource>();
+			
+			// Set it upright so it looks in the proper direction
+			RectTransform.localRotation = Quaternion.identity;
 		}
 
 		/// <summary>


### PR DESCRIPTION
## Summary of pull request
I fixed the error where UiWidgets would, by default, look in the incorrect direction. See picture below.
![epicrotationfail](https://user-images.githubusercontent.com/48143760/122627766-ad309b80-d07f-11eb-843d-b307a3c5e982.png)
UiWidgets now have `RectTransform.localRotation = Quaternion.identity;` in their Awake function.

## PR Checklist
* [ ] I have tested my changes (i think this change is small enough it'd be an award to fuck it up)
* [ ] I have updated any relevent documentation (bug fix; no mention of bugs in docs)