### PR TITLE
Mark existing get chambers obsolete

### DIFF
--- a/src/Sodalite/Sodalite.csproj
+++ b/src/Sodalite/Sodalite.csproj
@@ -48,7 +48,7 @@
         <PackageReference Include="jnm2.ReferenceAssemblies.net35" Version="1.0.1" PrivateAssets="all" />
         <PackageReference Include="Nullable" Version="1.3.0" PrivateAssets="all" />
         <PackageReference Include="UnityEngine" Version="5.6.1" />
-        <PackageReference Include="H3VR.GameLibs" Version="0.100.5-r.0" />
+        <PackageReference Include="H3VR.GameLibs" Version="0.100.6-r.0" />
     </ItemGroup>
 
     <ItemGroup Condition="'$(Configuration)'=='Runtime'">

--- a/src/Sodalite/src/Api/Firearm.cs
+++ b/src/Sodalite/src/Api/Firearm.cs
@@ -148,6 +148,7 @@ namespace Sodalite.Api
 		/// </summary>
 		/// <param name="firearm">The firearm to get the chambers of</param>
 		/// <returns>An array of chambers belonging to this weapon</returns>
+		[Obsolete("Vanilla game has this method now. Please use FVRFireArm.GetChambers() instead.")]
 		public static FVRFireArmChamber[] GetFirearmChambers(FVRFireArm firearm)
 		{
 			// Return a new array with the chamber, or chambers if the gun has multiple.


### PR DESCRIPTION
<!-- What did you add, change, or fix? Provide as much detail as possible. -->
## Summary of pull request
Marked `FirearmAPI.GetFirearmChambers()` as obsolete as vanilla game now includes this method.
